### PR TITLE
Fix zsh-incompatible which guards and add zsh custom prompt

### DIFF
--- a/bash.d/bash_completion.sh
+++ b/bash.d/bash_completion.sh
@@ -5,7 +5,7 @@ for file in /usr/local/etc/bash_completion /opt/local/etc/bash_completion /etc/b
 done
 
 # Special homebrew version
-if [ "" != "`which brew 2> /dev/null `" ] ; then
+if command -v brew > /dev/null 2>&1 ; then
   if [ -f $(brew --prefix)/etc/bash_completion ]; then
     . $(brew --prefix)/etc/bash_completion
   fi

--- a/bash.d/bash_extras.sh
+++ b/bash.d/bash_extras.sh
@@ -8,7 +8,7 @@ nonascii() { LANG=C grep --color=always '[^ -~]\+'; }
 export HISTCONTROL=erasedups
 
 
-if [ "" != "`which tput 2> /dev/null `" ] ; then
+if command -v tput > /dev/null 2>&1 ; then
   alias diffw='diff -W $(( $(tput cols) - 2 ))'
 else
   alias diffw='diff -W $(( $COLUMNS - 2 ))'

--- a/bash.d/bash_prompt.sh
+++ b/bash.d/bash_prompt.sh
@@ -56,9 +56,9 @@ parse_aws_info() {
 
 _RUBY_CHECK=""
 if [ "$ENABLE_RUBY_PROMPT" = "true" ] ; then
-  if [ "" != "`which rbenv 2> /dev/null `" ] ; then
+  if command -v rbenv > /dev/null 2>&1 ; then
     _RUBY_CHECK=rbenv
-  elif [ "" != "`which rvm 2> /dev/null `" ] ; then
+  elif command -v rvm > /dev/null 2>&1 ; then
     _RUBY_CHECK=rvm
   fi
 fi
@@ -217,13 +217,13 @@ PS_END="\n\[${_RESET}\]$ "
 PS_TIME="\[${_MAGENTA}\]\$(prompt_time)"
 
 # Extra stuff
-if [ "" != "`which git 2> /dev/null `" ] ; then
+if command -v git > /dev/null 2>&1 ; then
   PS_GIT="\[${_CYAN}\]\$(parse_git_info)"
 else
   PS_GIT=
 fi
 
-if [ "" != "`which svn 2> /dev/null `" ] ; then
+if command -v svn > /dev/null 2>&1 ; then
   PS_SVN="\[${_CYAN}\]\$(parse_svn_info)"
 else
   PS_SVN=

--- a/sh.d/git.sh
+++ b/sh.d/git.sh
@@ -1,4 +1,4 @@
-if [ "" != "`which git 2> /dev/null `" ] ; then
+if command -v git > /dev/null 2>&1 ; then
     function git_all_status() {
         for g in */.git ; do
             cd $(dirname $g)

--- a/sh.d/go.sh
+++ b/sh.d/go.sh
@@ -1,7 +1,7 @@
 
 # Various setup things related to golang
 
-if [ "" != "`which go 2> /dev/null `" ] ; then
+if command -v go > /dev/null 2>&1 ; then
 
     if [ "" = "$GOPATH" ] ; then
         GOPATH=~/.gocode

--- a/sh.d/maven.sh
+++ b/sh.d/maven.sh
@@ -1,6 +1,6 @@
 
 # Setup custom maven shortcuts
-if [ "" != "`which mvn 2> /dev/null `" ] ; then
+if command -v mvn > /dev/null 2>&1 ; then
     function m() {
         start=`pwd`
         found=false

--- a/sh.d/python.sh
+++ b/sh.d/python.sh
@@ -1,11 +1,11 @@
 
-if [ "" != "`which python 2> /dev/null `" ] ; then
+if command -v python > /dev/null 2>&1 ; then
     function pyserver() {
         python -m SimpleHTTPServer
     }
 
     # Pretty print json: echo '{"json":{"foo":"bar", "baz":"blah"}}'  | jsonpp
-    if [ "" != "`which jq 2> /dev/null `" ] ; then
+    if command -v jq > /dev/null 2>&1 ; then
         alias jsonpp="jq ."
     else
         alias jsonpp="python -m json.tool"

--- a/sh.d/ruby.sh
+++ b/sh.d/ruby.sh
@@ -1,4 +1,4 @@
-if [ "" != "`which rbenv 2> /dev/null `" ] ; then
+if command -v rbenv > /dev/null 2>&1 ; then
     eval " $(rbenv init - )"
 
     # Handy ruby things
@@ -73,7 +73,7 @@ if [ "" != "`which rbenv 2> /dev/null `" ] ; then
       done
     }
 
-  if [ "" != "`which rspec 2> /dev/null `" ] ; then
+  if command -v rspec > /dev/null 2>&1 ; then
       alias rspec="rspec -c -f d"
   fi
 else

--- a/zsh.d/prompt.zsh
+++ b/zsh.d/prompt.zsh
@@ -39,4 +39,130 @@ if command -v powerline-go >& /dev/null && test ! -n "${SKIP_POWERLINE+1}" ; the
       install_powerline_precmd
   fi
 
+else
+
+  # Custom zsh prompt — used when powerline-go is not available or SKIP_POWERLINE is set
+
+  setopt PROMPT_SUBST
+
+  parse_git_info() {
+    if [ "" = "${SKIP_GIT_STATUS}" ] ; then
+      GIT_BRANCH=$(git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/git:\1/')
+      GIT_EXTRA=$(git status --porcelain 2> /dev/null | cut -c 1-2 | tr "?" "N" | extsed 's/(.)/-\1/g' | tr "-" "\n" | sort | uniq | tr "\n" " " | sed "s/ //g")
+    else
+      GIT_BRANCH='git:unknown'
+      GIT_EXTRA='skip'
+    fi
+    if [ "$GIT_EXTRA" = "" ] ; then
+      echo "$GIT_BRANCH"
+    else
+      echo "$GIT_BRANCH (${GIT_EXTRA})"
+    fi
+  }
+
+  parse_aws_info() {
+    # To enable this the _AWS_CHECK variable will need to be defined somewhere else
+    if [ "$_AWS_CHECK" = "" ] ; then
+      TRY_EC2=false
+      # Note, this is not the best check, but it's quick and should work for me
+      uname -a | grep amzn >& /dev/null && TRY_EC2=true
+      if [ "$TRY_EC2" = "true" ] ; then
+        AWS_PROMPT=AWS
+      fi
+      _AWS_CHECK=true
+    fi
+    echo -n $AWS_PROMPT
+  }
+
+  __DO_UNICODE=false
+  [[ "$(locale charmap 2>/dev/null)" = "UTF-8" ]] && __DO_UNICODE=true
+  export __DO_UNICODE
+
+  prompt_time() {
+    p_icon=
+    if [ "$__DO_UNICODE" = "true" ] ; then
+      declare -i t_hour=$(date +%H%M | sed 's/^0*//')
+      if [[ $t_hour -lt 600 ]] ; then
+        p_icon="☣  "
+      elif [[ $t_hour -lt 1100 ]] ; then
+        p_icon="☕  "
+      elif [[ $t_hour -lt 1330 ]] ; then
+        p_icon="🍔  "
+      elif [[ $t_hour -lt 1600 ]] ; then
+        p_icon="☀  "
+      elif [[ $t_hour -lt 2200 ]] ; then
+        p_icon="🍺  "
+      else
+        p_icon="☣  "
+      fi
+    fi
+    echo -n "${p_icon}$(date +%Y-%m-%d\ %H:%M:%S)"
+  }
+
+  # Color setup using tput
+  if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color >/dev/null 2>&1; then
+    export TERM=gnome-256color
+  elif infocmp xterm-256color >/dev/null 2>&1; then
+    export TERM=xterm-256color
+  fi
+
+  HAS_TPUT=
+  tput setaf 1 &> /dev/null && HAS_TPUT=true
+  if [ "$HAS_TPUT" = "true" ] ; then
+    tput sgr0
+    if [[ $(tput colors) -ge 256 ]] ; then
+      _BLACK=$(tput setaf 0)
+      _RED=$(tput setaf 124)
+      _GREEN=$(tput setaf 46)
+      _YELLOW=$(tput setaf 192)
+      _BLUE=$(tput setaf 25)
+      _MAGENTA=$(tput setaf 129)
+      _CYAN=$(tput setaf 51)
+      _WHITE=$(tput setaf 15)
+      _BRIGHT_YELLOW=$(tput setaf 226)
+    else
+      _BLACK=$(tput setaf 0)
+      _RED=$(tput setaf 1)
+      _GREEN=$(tput setaf 2)
+      _YELLOW=$(tput setaf 3)
+      _BLUE=$(tput setaf 4)
+      _MAGENTA=$(tput setaf 5)
+      _CYAN=$(tput setaf 6)
+      _WHITE=$(tput setaf 7)
+      _BRIGHT_YELLOW=$(tput setaf 3)
+    fi
+    _BOLD=$(tput bold)
+    _RESET=$(tput sgr0)
+  else
+    _BLACK="\033[30m"
+    _RED="\033[31m"
+    _GREEN="\033[32m"
+    _YELLOW="\033[33m"
+    _BLUE="\033[34m"
+    _MAGENTA="\033[35m"
+    _CYAN="\033[36m"
+    _WHITE="\033[37m"
+    _BOLD=""
+    _RESET="\033[m"
+    _BRIGHT_YELLOW="\033[33m"
+  fi
+
+  export _BLACK _RED _GREEN _YELLOW _BLUE _MAGENTA _CYAN _WHITE _BOLD _RESET
+
+  # Build prompt pieces
+  _PS_USER="%{${_GREEN}%}%n%{${_WHITE}%}@%{${_BRIGHT_YELLOW}%}%m"
+  _PS_TIME="%{${_MAGENTA}%}\$(prompt_time)"
+  _PS_STATUS="%(?.%{${_GREEN}%}0%{${_RESET}%}.%{${_RED}%}%?%{${_RESET}%})"
+  _PS_DIR="%{${_YELLOW}%}%~"
+
+  if command -v git > /dev/null 2>&1 ; then
+    _PS_GIT="%{${_CYAN}%}\$(parse_git_info)"
+  else
+    _PS_GIT=
+  fi
+
+  _PS_AWS="%{${_WHITE}%}\$(parse_aws_info)"
+
+  PROMPT=$'\n'"${_PS_USER} ${_PS_TIME} %{${_YELLOW}%}[${_PS_STATUS}%{${_YELLOW}%}]"$'\n'"${_PS_DIR} ${_PS_GIT} ${_PS_AWS}%{${_RESET}%}"$'\n'"$ "
+
 fi


### PR DESCRIPTION
## Summary

- Replace backtick-`which` guards with `command -v cmd > /dev/null 2>&1` across sh.d and bash.d — zsh's `which` builtin outputs `"cmd not found"` to stdout when a command is missing, causing the guard to incorrectly pass and trigger errors like `ruby.sh:2: command not found: rbenv`
- Add a custom zsh prompt to `zsh.d/prompt.zsh` as a fallback when powerline-go is absent; ports `parse_git_info`, `parse_aws_info`, and `prompt_time` (with emoji time icons) from `bash_prompt.sh` — SVN and Ruby omitted

## Files changed

| File | Change |
|------|--------|
| `sh.d/ruby.sh` | Fix `rbenv`, `rspec` guards (root cause of the startup error) |
| `sh.d/go.sh`, `maven.sh`, `git.sh` | Fix tool presence guards |
| `sh.d/python.sh` | Fix `python`, `jq` guards |
| `bash.d/bash_extras.sh`, `bash_completion.sh` | Fix `tput`, `brew` guards |
| `bash.d/bash_prompt.sh` | Fix `git`, `svn`, `rbenv`, `rvm` guards |
| `zsh.d/prompt.zsh` | Add custom prompt as else branch of powerline block |

## Test plan

- [ ] Source shell_config.sh in zsh — no errors on startup
- [ ] Verify prompt appears in zsh when `SKIP_POWERLINE=1`
- [ ] Powerline still takes precedence when powerline-go is installed
- [ ] Git branch/status shows in zsh prompt inside a repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)