### PR TITLE
Add fzf and mcfly shell integration

### DIFF
--- a/sh.d/fzf.sh
+++ b/sh.d/fzf.sh
@@ -1,0 +1,8 @@
+
+if command -v fzf > /dev/null 2>&1; then
+  if [ -n "$BASH_VERSION" ]; then
+    eval "$(fzf --bash)"
+  elif [ -n "$ZSH_VERSION" ]; then
+    source <(fzf --zsh)
+  fi
+fi

--- a/sh.d/mcfly.sh
+++ b/sh.d/mcfly.sh
@@ -1,0 +1,9 @@
+
+if command -v mcfly > /dev/null 2>&1; then
+  export MCFLY_FUZZY=2
+  if [ -n "$BASH_VERSION" ]; then
+    eval "$(mcfly init bash)"
+  elif [ -n "$ZSH_VERSION" ]; then
+    eval "$(mcfly init zsh)"
+  fi
+fi


### PR DESCRIPTION
## Summary

- Adds `sh.d/fzf.sh` — sets up fzf key bindings and completion for bash (`fzf --bash`) and zsh (`fzf --zsh`), guarded by a `command -v fzf` check
- Adds `sh.d/mcfly.sh` — initializes mcfly history search for bash and zsh with `MCFLY_FUZZY=2`, guarded by a `command -v mcfly` check

Both files follow the existing `sh.d/` convention of no-op when the tool isn't installed.

## Test plan

- [ ] Source shell config on a machine with fzf installed — verify `ctrl-r`, `ctrl-t`, `alt-c` bindings work
- [ ] Source shell config on a machine with mcfly installed — verify `ctrl-r` launches mcfly
- [ ] Source shell config without either tool — verify no errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)