### PR TITLE
Add supply chain age-gate protection across package ecosystems

### DIFF
--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -1,0 +1,9 @@
+# Cargo configuration (~/.cargo/config.toml)
+# Supply chain protection notes:
+#   - Use 'cargo-install' alias (in sh.d/cargo-age-gate.sh) for --locked installs
+#   - Use 'cargo-safe' alias to run cargo-audit + cargo-vet before building
+#   - cargo-cooldown (COOLDOWN_MINUTES env var) wraps cargo for age enforcement
+
+[net]
+# Use system git binary (avoids libgit2 supply chain exposure)
+git-fetch-with-cli = true

--- a/config/uv/uv.toml
+++ b/config/uv/uv.toml
@@ -1,0 +1,8 @@
+# uv configuration
+# Supply chain protection: block packages published less than 10 days ago.
+# Override per-command: uv add --no-config <pkg>
+# Override per-package in pyproject.toml:
+#   [tool.uv.exclude-newer-package]
+#   my-private-pkg = false
+
+exclude-newer = "10 days"

--- a/gemrc
+++ b/gemrc
@@ -1,0 +1,7 @@
+# RubyGems configuration (~/.gemrc)
+# Supply chain protection: gem.coop mirrors rubygems.org with a built-in 48h cooldown.
+# gem.coop is listed first so it is used preferentially.
+# Bundler: set source "https://gem.coop" in your Gemfiles to get the same cooldown.
+:sources:
+- https://gem.coop/
+- https://rubygems.org/

--- a/npmrc
+++ b/npmrc
@@ -1,0 +1,5 @@
+# npm user config (~/.npmrc)
+# Supply chain protection: block packages published less than 10 days ago.
+# Override: npm install <pkg> --min-release-age=0
+min-release-age=10
+ignore-scripts=true

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,16 @@ linkit vim .vim
 linkit tmux.conf .tmux.conf
 linkit gitconfig .gitconfig
 linkit gitignore_global .gitignore_global
+linkit npmrc .npmrc
+linkit yarnrc.yml .yarnrc.yml
+linkit gemrc .gemrc
+linkit zshenv .zshenv
+
+# Config files in nested directories require the parent dir to exist first
+mkdir -p ~/.config/uv
+linkit config/uv/uv.toml .config/uv/uv.toml
+mkdir -p ~/.cargo
+linkit cargo-config.toml .cargo/config.toml
 
 mkdir -p ~/bin
 

--- a/sh.d/brew-age-gate.sh
+++ b/sh.d/brew-age-gate.sh
@@ -1,0 +1,143 @@
+
+# Supply chain protection for Homebrew.
+# Wraps 'brew install', 'brew reinstall', and 'brew upgrade' with an age check.
+# Blocks bare 'brew upgrade' (no args) because it upgrades all formulae at once.
+# Bypass: command brew install <formula>
+
+if command -v brew > /dev/null 2>&1; then
+
+  # Internal helper: check one formula/cask name against the local tap.
+  # Returns 0 (OK), 1 (blocked), 2 (tap not available — caller decides).
+  _brew_check_age() {
+    local name="$1"
+    local min_days="${2:-10}"
+    local is_cask="${3:-}"
+
+    local tap_path subdir
+    tap_path="$(brew --prefix)/Library/Taps/homebrew"
+
+    if [ -n "$is_cask" ]; then
+      subdir="$tap_path/homebrew-cask/Casks"
+      # Cask files live under a single-letter subdirectory
+      local first_char
+      first_char="$(printf '%s' "$name" | cut -c1)"
+      local formula_file="$subdir/$first_char/$name.rb"
+      [ -f "$formula_file" ] || formula_file="$subdir/$name.rb"
+    else
+      subdir="$tap_path/homebrew-core/Formula"
+      local first_char
+      first_char="$(printf '%s' "$name" | cut -c1)"
+      local formula_file="$subdir/$first_char/$name.rb"
+      [ -f "$formula_file" ] || formula_file="$subdir/$name.rb"
+    fi
+
+    if [ ! -d "$tap_path/homebrew-core" ] && [ -z "$is_cask" ]; then
+      # Tap not cloned; caller handles this
+      return 2
+    fi
+
+    if [ ! -f "$formula_file" ]; then
+      echo "INFO: No local formula file found for '$name'; skipping age check." >&2
+      return 0
+    fi
+
+    # Use committer date (%ci) — harder to backdate than author date (%ai)
+    local commit_date
+    local tap_dir
+    tap_dir="$(dirname "$(dirname "$formula_file")")"
+    commit_date=$(git -C "$tap_dir" log -1 --format="%ci" -- "$formula_file" 2>/dev/null | awk '{print $1}')
+
+    if [ -z "$commit_date" ]; then
+      echo "WARNING: Could not determine formula age for '$name'; allowing install." >&2
+      return 0
+    fi
+
+    local formula_epoch now_epoch age_days
+    formula_epoch=$(date -j -f "%Y-%m-%d" "$commit_date" +%s 2>/dev/null \
+                    || date -d "$commit_date" +%s 2>/dev/null)
+    now_epoch=$(date +%s)
+    age_days=$(( (now_epoch - formula_epoch) / 86400 ))
+
+    if [ "$age_days" -lt "$min_days" ]; then
+      echo "BLOCKED: '$name' formula last modified ${age_days} days ago (minimum: ${min_days})." >&2
+      echo "         Wait $((min_days - age_days)) more days, or bypass: command brew $subcmd $name" >&2
+      return 1
+    fi
+
+    return 0
+  }
+
+  _brew_tap_missing_message() {
+    echo "BLOCKED: homebrew-core tap not cloned; cannot verify formula age." >&2
+    echo "  To enable age checks (one-time, ~2 GB):" >&2
+    echo "    export HOMEBREW_NO_INSTALL_FROM_API=1  # add to ~/.zshenv" >&2
+    echo "    brew tap homebrew/core" >&2
+    echo "  To bypass age check: command brew $*" >&2
+  }
+
+  brew() {
+    local subcmd="$1"
+    case "$subcmd" in
+
+      install|reinstall)
+        shift
+        local is_cask=""
+        local names=()
+        for arg in "$@"; do
+          case "$arg" in
+            --cask) is_cask="1" ;;
+            --*) ;;   # skip other flags
+            *) names+=("$arg") ;;
+          esac
+        done
+
+        if [ -n "$is_cask" ]; then
+          echo "INFO: Cask installs cannot be age-checked; proceeding." >&2
+        else
+          for name in "${names[@]:-}"; do
+            [ -z "$name" ] && continue
+            _brew_check_age "$name" 10 "$is_cask"
+            local rc=$?
+            if [ $rc -eq 2 ]; then
+              _brew_tap_missing_message "$subcmd" "$@"
+              return 1
+            elif [ $rc -ne 0 ]; then
+              return 1
+            fi
+          done
+        fi
+        command brew "$subcmd" "$@"
+        ;;
+
+      upgrade)
+        if [ $# -eq 1 ]; then
+          # bare 'brew upgrade' — upgrades everything; too risky to do unreviewed
+          echo "BLOCKED: 'brew upgrade' (no arguments) upgrades all formulae at once." >&2
+          echo "  Upgrade packages individually after checking age:" >&2
+          echo "    brew outdated" >&2
+          echo "    brew upgrade <formula>   # age-gated per-formula" >&2
+          echo "  To bypass: command brew upgrade" >&2
+          return 1
+        fi
+        shift
+        for arg in "$@"; do
+          case "$arg" in --*) continue ;; esac
+          _brew_check_age "$arg" 10
+          local rc=$?
+          if [ $rc -eq 2 ]; then
+            _brew_tap_missing_message "upgrade" "$@"
+            return 1
+          elif [ $rc -ne 0 ]; then
+            return 1
+          fi
+        done
+        command brew upgrade "$@"
+        ;;
+
+      *)
+        command brew "$@"
+        ;;
+    esac
+  }
+
+fi

--- a/sh.d/cargo-age-gate.sh
+++ b/sh.d/cargo-age-gate.sh
@@ -1,0 +1,32 @@
+
+# Supply chain protection for Rust/Cargo
+#
+# COVERAGE GAPS (no shell-level workaround):
+#   cargo add, cargo update, cargo build  — all can pull new crates without age checks
+#   unless cargo-cooldown is installed and used explicitly.
+#
+# To get real enforcement: install cargo-cooldown and use cargo-build-safe / cargo-add-safe.
+#   cargo install --locked cargo-cooldown
+
+if command -v cargo > /dev/null 2>&1; then
+
+  # Always prefer --locked (respects exact Cargo.lock; avoids silent updates)
+  alias cargo-install='cargo install --locked'
+
+  # cargo-cooldown (crates.io/crates/cargo-cooldown) enforces a minimum crate age
+  # for any cargo subcommand. COOLDOWN_MINUTES=14400 = 10 days.
+  # COOLDOWN_MODE=warn to observe without blocking first.
+  if command -v cargo-cooldown > /dev/null 2>&1; then
+    alias cargo-build-safe='COOLDOWN_MINUTES=14400 cargo-cooldown build'
+    alias cargo-add-safe='COOLDOWN_MINUTES=14400 cargo-cooldown add'
+    alias cargo-update-safe='COOLDOWN_MINUTES=14400 cargo-cooldown update'
+  fi
+
+  # cargo-safe: run security audit and vet before building
+  if command -v cargo-audit > /dev/null 2>&1 && command -v cargo-vet > /dev/null 2>&1; then
+    alias cargo-safe='cargo audit && cargo vet'
+  elif command -v cargo-audit > /dev/null 2>&1; then
+    alias cargo-safe='cargo audit'
+  fi
+
+fi

--- a/sh.d/go-age-gate.sh
+++ b/sh.d/go-age-gate.sh
@@ -1,0 +1,54 @@
+
+# Supply chain protection for Go modules
+
+if command -v go > /dev/null 2>&1; then
+
+  # go-cooldown proxy (github.com/imjasonh/go-cooldown) provides age-gating
+  # at the GOPROXY level. If running locally, set:
+  #   export GOPROXY=http://localhost:8080/10d,direct
+  # The proxy returns 404 for modules newer than the window, causing go to
+  # fall back to the next proxy or fail. Start it with:
+  #   UPSTREAM_PROXY=https://proxy.golang.org go-cooldown
+  #
+  # Without go-cooldown, go-check-age below is an advisory check.
+
+  # Advisory check: query proxy.golang.org for a module's publish timestamp.
+  # Usage: go-check-age <module-path> [min-days]
+  # Example: go-check-age golang.org/x/text 10
+  go-check-age() {
+    local pkg="${1:?Usage: go-check-age <module-path> [min-days]}"
+    local min_days="${2:-10}"
+
+    local info ts pkg_epoch now_epoch age_days
+
+    info=$(curl -sf "https://proxy.golang.org/${pkg}/@latest" 2>/dev/null)
+    if [ -z "$info" ]; then
+      echo "WARNING: Could not query proxy.golang.org for $pkg" >&2
+      return 1
+    fi
+
+    ts=$(printf '%s' "$info" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('Time',''))" 2>/dev/null)
+    if [ -z "$ts" ]; then
+      echo "WARNING: No timestamp in proxy response for $pkg" >&2
+      return 1
+    fi
+
+    pkg_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null \
+                || date -d "$ts" +%s 2>/dev/null)
+    now_epoch=$(date +%s)
+    age_days=$(( (now_epoch - pkg_epoch) / 86400 ))
+
+    if [ "$age_days" -lt "$min_days" ]; then
+      echo "BLOCKED: $pkg is only ${age_days} days old (minimum: ${min_days} days)" >&2
+      echo "  To override: command go get $pkg" >&2
+      return 1
+    fi
+
+    echo "OK: $pkg is ${age_days} days old (minimum: ${min_days})"
+  }
+
+  if command -v govulncheck > /dev/null 2>&1; then
+    alias go-vulncheck='govulncheck ./...'
+  fi
+
+fi

--- a/sh.d/pip-age-gate.sh
+++ b/sh.d/pip-age-gate.sh
@@ -1,0 +1,77 @@
+
+# Supply chain protection: block pip install/download of packages < 10 days old.
+#
+# This shell function intercepts bare `pip` / `pip3` invocations only.
+# The following paths BYPASS this function and are covered by PIP_UPLOADED_PRIOR_TO
+# in ~/.zshenv instead (which is inherited by all processes):
+#   - python -m pip install
+#   - ./venv/bin/pip install
+#   - pipx install
+#   - scripts, Makefiles, IDE tasks
+#
+# If pip < 26.0 is detected, the flag is not injected (unknown option = hard fail),
+# and a warning is printed instead so the user knows protection is absent.
+# Bypass: command pip install <pkg>
+
+_pip_age_cutoff() {
+  date -u -v-10d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d '10 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+}
+
+_pip_supports_age_gate() {
+  local ver
+  ver=$(command "${1:-pip}" --version 2>/dev/null | awk '{print $2}' | cut -d. -f1)
+  [ -n "$ver" ] && [ "$ver" -ge 26 ] 2>/dev/null
+}
+
+pip() {
+  local subcmd="$1"
+  case "$subcmd" in
+    install|download)
+      shift
+      if _pip_supports_age_gate pip; then
+        local cutoff
+        cutoff="$(_pip_age_cutoff)"
+        if [ -n "$cutoff" ]; then
+          command pip "$subcmd" --uploaded-prior-to "$cutoff" "$@"
+        else
+          echo "WARNING: could not compute age cutoff; running pip without age gate" >&2
+          command pip "$subcmd" "$@"
+        fi
+      else
+        echo "WARNING: pip < 26.0 detected; --uploaded-prior-to not supported." >&2
+        echo "         Age gate is inactive for this pip. Upgrade: pip install --upgrade pip" >&2
+        command pip "$subcmd" "$@"
+      fi
+      ;;
+    *)
+      command pip "$@"
+      ;;
+  esac
+}
+
+pip3() {
+  local subcmd="$1"
+  case "$subcmd" in
+    install|download)
+      shift
+      if _pip_supports_age_gate pip3; then
+        local cutoff
+        cutoff="$(_pip_age_cutoff)"
+        if [ -n "$cutoff" ]; then
+          command pip3 "$subcmd" --uploaded-prior-to "$cutoff" "$@"
+        else
+          echo "WARNING: could not compute age cutoff; running pip3 without age gate" >&2
+          command pip3 "$subcmd" "$@"
+        fi
+      else
+        echo "WARNING: pip3 < 26.0 detected; --uploaded-prior-to not supported." >&2
+        echo "         Age gate is inactive. Upgrade: pip3 install --upgrade pip" >&2
+        command pip3 "$subcmd" "$@"
+      fi
+      ;;
+    *)
+      command pip3 "$@"
+      ;;
+  esac
+}

--- a/sh.d/pnpm-age-gate.sh
+++ b/sh.d/pnpm-age-gate.sh
@@ -1,0 +1,26 @@
+
+# Supply chain protection for pnpm.
+# pnpm does not read ignore-scripts or min-release-age from .npmrc.
+# These must be set via pnpm's own config.
+#
+# Checks the actual config values on each shell start and self-heals if they've
+# been wiped (e.g., pnpm config delete, new pnpm store, machine restore).
+# Cost: one 'pnpm config get' call per shell start — fast.
+
+if command -v pnpm > /dev/null 2>&1; then
+
+  _pnpm_expected_age=14400  # minutes = 10 days
+
+  _pnpm_current_age="$(pnpm config get minimum-release-age 2>/dev/null)"
+  if [ "$_pnpm_current_age" != "$_pnpm_expected_age" ]; then
+    pnpm config set minimum-release-age "$_pnpm_expected_age" --global 2>/dev/null
+  fi
+
+  _pnpm_current_scripts="$(pnpm config get ignore-scripts 2>/dev/null)"
+  if [ "$_pnpm_current_scripts" != "true" ]; then
+    pnpm config set ignore-scripts true --global 2>/dev/null
+  fi
+
+  unset _pnpm_expected_age _pnpm_current_age _pnpm_current_scripts
+
+fi

--- a/sh.d/python.sh
+++ b/sh.d/python.sh
@@ -1,14 +1,21 @@
 
-if command -v python > /dev/null 2>&1 ; then
+if command -v python3 > /dev/null 2>&1 ; then
+    _python=python3
+elif command -v python > /dev/null 2>&1 ; then
+    _python=python
+fi
+
+if [ -n "${_python:-}" ] ; then
     function pyserver() {
-        python -m SimpleHTTPServer
+        $_python -m http.server "${1:-8000}"
     }
 
     # Pretty print json: echo '{"json":{"foo":"bar", "baz":"blah"}}'  | jsonpp
     if command -v jq > /dev/null 2>&1 ; then
         alias jsonpp="jq ."
     else
-        alias jsonpp="python -m json.tool"
+        alias jsonpp="$_python -m json.tool"
     fi
-fi
 
+    unset _python
+fi

--- a/sh.d/ruby-age-gate.sh
+++ b/sh.d/ruby-age-gate.sh
@@ -1,0 +1,27 @@
+
+# Supply chain protection for Ruby/Bundler
+# gem.coop provides a 48-hour built-in cooldown (not 10 days — best available for Ruby).
+#
+# IMPORTANT: ~/.gemrc source ordering is ignored by Bundler when a Gemfile has
+# an explicit `source "https://rubygems.org"` line — which every real project does.
+# The only way to enforce gem.coop for Bundler without editing every Gemfile is the
+# global mirror config below, which rewrites sources at fetch time transparently.
+
+if command -v bundle > /dev/null 2>&1; then
+
+  # Set gem.coop as a transparent mirror for rubygems.org in Bundler.
+  # This rewrites all `source "https://rubygems.org"` Gemfile lines at fetch time
+  # so existing projects get the cooldown without manual Gemfile edits.
+  # Self-heals if the config is wiped.
+  _bundle_mirror="$(bundle config get mirror.https://rubygems.org 2>/dev/null)"
+  if [ "$_bundle_mirror" != "https://gem.coop/" ] && [ "$_bundle_mirror" != "https://gem.coop" ]; then
+    bundle config set --global mirror.https://rubygems.org https://gem.coop/ 2>/dev/null
+  fi
+  unset _bundle_mirror
+
+  if command -v bundle-audit > /dev/null 2>&1; then
+    # Update advisory DB and check current Gemfile.lock for known CVEs
+    alias bundle-audit-update='bundle-audit update && bundle-audit check'
+  fi
+
+fi

--- a/sh.d/ruby.sh
+++ b/sh.d/ruby.sh
@@ -1,5 +1,5 @@
 if command -v rbenv > /dev/null 2>&1 ; then
-    eval " $(rbenv init - )"
+    eval "$(rbenv init -)"
 
     # Handy ruby things
     alias be="bundle exec"

--- a/yarnrc.yml
+++ b/yarnrc.yml
@@ -1,0 +1,5 @@
+# Yarn Berry configuration (~/.yarnrc.yml)
+# Supply chain protection: block packages published less than 10 days ago.
+# Override: yarn add <pkg> --min-release-age 0
+npmMinimalAgeGate: "10d"
+enableScripts: false

--- a/zshenv
+++ b/zshenv
@@ -1,0 +1,28 @@
+# ~/.zshenv — sourced for ALL zsh instances: interactive, non-interactive, scripts, Makefiles.
+# Keep this file to env-var exports only. No aliases, no functions, no prompts.
+#
+# PURPOSE: supply chain age-gate env vars must live here (not in .zshrc / sh.d)
+# because shell functions defined in sh.d are NOT inherited by subshells, Makefiles,
+# VS Code tasks, or any non-interactive process.
+
+# --- uv (Python) ---
+# Overrides user config AND per-project uv.toml; survives --no-config.
+export UV_EXCLUDE_NEWER="10 days"
+
+# --- pip (Python) ---
+# Inherited by: python -m pip, pipx-launched pip, venv pip, Makefile pip calls.
+# Requires pip >= 26.0; older pip silently ignores unknown env vars.
+# Recomputed each shell start so the window rolls forward automatically.
+export PIP_UPLOADED_PRIOR_TO="$(date -u -v-10d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '10 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+
+# --- npm ---
+# Env vars beat per-project .npmrc files (which could set min-release-age=0).
+export NPM_CONFIG_MIN_RELEASE_AGE=10
+export NPM_CONFIG_IGNORE_SCRIPTS=true
+
+# --- Homebrew ---
+# Prevent silent tap updates pulling in new (unreviewed) formula versions.
+export HOMEBREW_NO_AUTO_UPDATE=1
+# Uncomment to enable formula-age checks in the brew() wrapper (requires ~2GB tap clone):
+#   export HOMEBREW_NO_INSTALL_FROM_API=1
+# After setting, run once: brew tap homebrew/core


### PR DESCRIPTION
## Summary

- Adds 10-day minimum package age enforcement across Python (uv/pip), Node (npm/yarn/pnpm), Ruby (Bundler), Go, Rust (cargo), and Homebrew to protect against supply chain attacks
- Exports critical env vars from `~/.zshenv` so protection is inherited by non-interactive shells, Makefiles, scripts, and IDE tasks — not just interactive terminals
- Wraps `brew` directly (not just `brew-safe`) so `brew install` is always gated; bare `brew upgrade` with no arguments is blocked
- Sets Bundler global mirror to gem.coop to transparently redirect all rubygems.org sources through a 48h cooldown proxy — works without editing Gemfiles
- Self-healing pnpm config: verifies and restores expected values on each shell start instead of using a fragile sentinel file

## New files

| File | Purpose |
|---|---|
| `zshenv` → `~/.zshenv` | Age-gate env vars inherited by all processes |
| `config/uv/uv.toml` → `~/.config/uv/uv.toml` | uv: `exclude-newer = "10 days"` |
| `npmrc` → `~/.npmrc` | npm: `min-release-age=10`, `ignore-scripts=true` |
| `yarnrc.yml` → `~/.yarnrc.yml` | Yarn Berry: `npmMinimalAgeGate: "10d"` |
| `gemrc` → `~/.gemrc` | gem: gem.coop as first source |
| `cargo-config.toml` → `~/.cargo/config.toml` | cargo: `git-fetch-with-cli = true` |
| `sh.d/pip-age-gate.sh` | pip/pip3 wrappers with version check |
| `sh.d/go-age-gate.sh` | `go-check-age` advisory function |
| `sh.d/brew-age-gate.sh` | `brew()` wrapper gating install/upgrade/reinstall |
| `sh.d/cargo-age-gate.sh` | `cargo-install --locked` alias, cargo-cooldown support |
| `sh.d/pnpm-age-gate.sh` | pnpm config self-heal on each shell start |
| `sh.d/ruby-age-gate.sh` | Bundler gem.coop mirror + bundle-audit alias |

## Known gaps

- Go and Rust have no native age-gating; `go-check-age` and `cargo-cooldown` are advisory/opt-in
- `python -m pip` bypasses the shell function; covered by `PIP_UPLOADED_PRIOR_TO` env var (requires pip ≥ 26.0)
- Homebrew age checks require `HOMEBREW_NO_INSTALL_FROM_API=1` + `brew tap homebrew/core` (one-time ~2 GB setup); without it the brew wrapper blocks installs and prints setup instructions
- Cask installs cannot be age-checked; brew wrapper warns and passes through
- Git/path/URL dependencies across all ecosystems have no timestamp semantics

## Test plan

- [ ] Source `shell_config.sh` and verify `pip install` injects `--uploaded-prior-to`
- [ ] Verify `uv add` respects `exclude-newer` via `UV_EXCLUDE_NEWER` env var
- [ ] Run `brew install wget` and confirm age check fires (or tap-not-cloned message)
- [ ] Confirm `brew upgrade` (no args) is blocked
- [ ] Verify `bundle config get mirror.https://rubygems.org` shows `https://gem.coop/`
- [ ] Check `npm config get min-release-age` returns `10`
- [ ] Run `setup.sh` on a clean machine and verify all symlinks are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)