### PR TITLE
feat(tmux): bigger choose-tree preview, smaller tree list

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -100,3 +100,12 @@ setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#W#[fg=colour244
 # Highlight inactive panes with grey background, keep active pane black
 set -g window-style 'bg=color236'
 set -g window-active-style 'bg=colour232'
+
+## Session and Window Preview (tree mode)
+# -N -N selects the "big preview": the tree list shrinks to at most a
+# quarter of the screen (or the exact number of tree lines, if fewer)
+# and the window previews get all remaining space. Requires tmux >= 3.4.
+# Inside the mode, `v` cycles preview size and `<`/`>` scroll the
+# preview boxes when a session has more windows than fit in one row.
+bind w choose-tree -Zw -N -N
+bind s choose-tree -Zs -N -N


### PR DESCRIPTION
## Summary
- Rebind `prefix+w` and `prefix+s` to `choose-tree` with `-N -N` (tmux >= 3.4), selecting tree mode's "big preview"
- The window list is capped at 1/4 of the screen (or the exact number of tree lines, if fewer); the window previews get all remaining space — stock gives the list up to 2/3
- Inside the mode, `v` still cycles preview size (Big → Normal → Off) and `<`/`>` scroll the preview row

Note: rendering the preview thumbnails in multiple rows is not possible via configuration — `window_tree_draw_session()` in tmux hard-codes a single scrollable row.

## Testing
- Verified in an isolated nested-tmux harness (tmux 3.6b, 2 sessions / 10 windows, real attached 180x45 client):
  - `prefix+w`: list 11 rows / preview 33 rows (stock: 22/21)
  - `prefix+s`: list 2 rows, preview gets the rest
  - `v` cycle, `<`/`>` scroll, 80x12 terminal degradation, and config reload all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)