### PR TITLE
loop-engineering: multiple loop projects per repo

### DIFF
--- a/bin/code-loop
+++ b/bin/code-loop
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Outer agentic-coding-loop runner: fresh Claude context per iteration
-# (avoids context rot; state lives in SPEC.md/TODO.md/LOOP_LOG.md/git).
-# Usage: code-loop [max_iterations]   (run from the target project root)
+# (avoids context rot; state lives in loops/<project>/{SPEC,TODO,LOOP_LOG}.md
+# and git).
+# Usage: code-loop <project> [max_iterations]   (run from the target repo root)
 #
 # Headless note: `claude -p` does NOT load plugin slash commands or hooks, so
 # this runner cannot use `/code-loop` and cannot rely on the Stop-hook gate.
@@ -12,13 +13,30 @@
 set -euo pipefail
 
 MAX_STRIKES=3
-max="${1:-10}"
-[ -f TODO.md ] && [ -f SPEC.md ] || { echo "SPEC.md/TODO.md not found — run /loop-init first" >&2; exit 2; }
+usage() {
+  echo "Usage: code-loop <project> [max_iterations]" >&2
+  if [ -d loops ]; then
+    echo "Available projects:" >&2
+    # shellcheck disable=SC2012  # project names are kebab-case slugs; ls is fine
+    ls loops 2>/dev/null | sed 's/^/  /' >&2
+  else
+    echo "No loops/ directory here — run /loop-init <project> first." >&2
+  fi
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+project="$1"
+max="${2:-10}"
+spec="loops/$project/SPEC.md"
+todo="loops/$project/TODO.md"
+log="loops/$project/LOOP_LOG.md"
+[ -f "$todo" ] && [ -f "$spec" ] || { echo "Project '$project' not found ($spec missing)." >&2; usage; }
 
 # Verify command, extracted from SPEC.md the same way /code-loop does.
 # shellcheck disable=SC2016  # backticks are literal SPEC.md markup, not expansion
-verify=$(sed -n 's/^Verify: `\(.*\)`.*/\1/p' SPEC.md | head -n1 | tr -d '`\r')
-[ -n "$verify" ] || { echo "SPEC.md ## Verification has no 'Verify:' command — run /loop-init" >&2; exit 2; }
+verify=$(sed -n 's/^Verify: `\(.*\)`.*/\1/p' "$spec" | head -n1 | tr -d '`\r')
+[ -n "$verify" ] || { echo "$spec ## Verification has no 'Verify:' command — run /loop-init" >&2; exit 2; }
 
 is_git=$(git rev-parse --is-inside-work-tree 2>/dev/null || echo false)
 
@@ -26,23 +44,24 @@ is_git=$(git rev-parse --is-inside-work-tree 2>/dev/null || echo false)
 build_prompt() {
   cat <<EOF
 You are one iteration of an agentic coding loop, working in the current
-directory (a git repository). Do exactly one thing: complete the TOPMOST
-unchecked item in TODO.md (a line starting with '- [ ]'), then stop.
+directory (a git repository) on the loop project '$project'. Do exactly one
+thing: complete the TOPMOST unchecked item in $todo (a line starting with
+'- [ ]'), then stop.
 
-=== SPEC.md ===
-$(cat SPEC.md)
+=== $spec ===
+$(cat "$spec")
 
-=== TODO.md ===
-$(cat TODO.md)
+=== $todo ===
+$(cat "$todo")
 
 Steps for this iteration:
-1. Take the topmost '- [ ]' item in TODO.md. Work on ONLY that item.
+1. Take the topmost '- [ ]' item in $todo. Work on ONLY that item.
 2. Implement it test-first with real, complete code — no stubs or placeholders.
 3. Run the verify command and make it pass: $verify
    Do NOT weaken tests, the verifier, the SPEC ## Verification section, or
    anything under .loop/ to make it pass — fix the real code instead.
-4. When verify passes, change that item's '- [ ]' to '- [x]' in TODO.md, append
-   a one-line note to LOOP_LOG.md, and commit everything (git add -A && commit).
+4. When verify passes, change that item's '- [ ]' to '- [x]' in $todo, append
+   a one-line note to $log, and commit everything (git add -A && commit).
 Then stop.
 EOF
 }
@@ -57,24 +76,24 @@ hack_reasons() { # before_ref after_ref
         echo "  test/verifier: $p" ;;
     esac
   done
-  if git diff --name-only "$before" "$after" 2>/dev/null | grep -q 'SPEC\.md$'; then
-    b=$(git show "$before:SPEC.md" 2>/dev/null \
+  if git diff --name-only "$before" "$after" 2>/dev/null | grep -qx "$spec"; then
+    b=$(git show "$before:$spec" 2>/dev/null \
         | awk '/^## Verification[[:space:]]*$/{s=1;next} /^## /{s=0} s')
-    h=$(awk '/^## Verification[[:space:]]*$/{s=1;next} /^## /{s=0} s' SPEC.md 2>/dev/null)
-    [ "$b" = "$h" ] || echo "  ## Verification section: SPEC.md"
+    h=$(awk '/^## Verification[[:space:]]*$/{s=1;next} /^## /{s=0} s' "$spec" 2>/dev/null)
+    [ "$b" = "$h" ] || echo "  ## Verification section: $spec"
   fi
   return 0
 }
 
 strikes=0
 for i in $(seq 1 "$max"); do
-  remaining=$(grep -c '^- \[ \]' TODO.md || true)
+  remaining=$(grep -c '^- \[ \]' "$todo" || true)
   if [ "${remaining:-0}" -eq 0 ]; then
     echo "TODO complete after $((i - 1)) iteration(s)."
     exit 0
   fi
-  item=$(grep -m1 '^- \[ \]' TODO.md)
-  echo "=== iteration $i/$max: $item ==="
+  item=$(grep -m1 '^- \[ \]' "$todo")
+  echo "=== $project iteration $i/$max: $item ==="
 
   before=""
   [ "$is_git" = true ] && before=$(git rev-parse HEAD 2>/dev/null || echo "")
@@ -103,7 +122,7 @@ for i in $(seq 1 "$max"); do
 
   # Verify enforcement (replaces the Stop-hook gate, which does not fire headless):
   # an iteration counts only if verify passes AND a TODO item got checked off.
-  now=$(grep -c '^- \[ \]' TODO.md || true)
+  now=$(grep -c '^- \[ \]' "$todo" || true)
   if bash -c "$verify" >/dev/null 2>&1 && [ "${now:-0}" -lt "${remaining:-0}" ]; then
     strikes=0
   else
@@ -111,15 +130,15 @@ for i in $(seq 1 "$max"); do
     echo "iteration $i: no verified progress (strike $strikes/$MAX_STRIKES)" >&2
     if [ "$strikes" -ge "$MAX_STRIKES" ]; then
       echo "FAILURE: $MAX_STRIKES iterations without verified progress on: $item" >&2
-      echo "Verify still fails or no TODO item completed. Review LOOP_LOG.md and the" >&2
+      echo "Verify still fails or no TODO item completed. Review $log and the" >&2
       echo "working tree; fix manually or refine SPEC/TODO, then re-run." >&2
       exit 1
     fi
   fi
 done
 
-if grep -q '^- \[ \]' TODO.md; then
-  echo "Budget exhausted ($max iterations); unchecked items remain. Review LOOP_LOG.md, then re-run or /feedback."
+if grep -q '^- \[ \]' "$todo"; then
+  echo "Budget exhausted ($max iterations); unchecked items remain. Review $log, then re-run or /feedback."
   exit 1
 fi
 echo "TODO complete after $max iteration(s)."

--- a/plugins/loop-engineering/.claude-plugin/plugin.json
+++ b/plugins/loop-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "loop-engineering",
-  "version": "0.1.0",
-  "description": "Development loops: agentic coding loop with verification gate, and developer feedback loop",
+  "version": "0.2.0",
+  "description": "Development loops: agentic coding loop with verification gate, developer feedback loop, and multiple loop projects per repo",
   "author": {
     "name": "jmeagher"
   },

--- a/plugins/loop-engineering/README.md
+++ b/plugins/loop-engineering/README.md
@@ -1,39 +1,52 @@
 # loop-engineering
 
-Two development loops (from Andrew Ng's three-loop model):
+Two development loops (from Andrew Ng's three-loop model), with support for
+multiple independent loop projects per repository. Each project lives in
+`loops/<name>/` with its own spec, backlog, and log.
 
-**Agentic coding loop** — `/loop-init` scaffolds SPEC.md (goal, definition of
-done, verify command), TODO.md (prioritized backlog), LOOP_LOG.md (append-only
-run log). `/code-loop [n]` works the backlog one item per iteration: test-first,
-verify, commit, log. A Stop hook (`hooks/verify-gate.sh`) blocks the agent from
-stopping until the project's verify command passes, with a 3-strike escalation
-that forces an honest FAILURE report instead of looping forever. For long
-unattended runs, `bin/code-loop [n]` re-invokes `claude -p "/code-loop 1"` with
-a fresh context per iteration.
+**Agentic coding loop** — `/loop-init <name>` scaffolds a project:
+`loops/<name>/SPEC.md` (goal, definition of done, verify command),
+`loops/<name>/TODO.md` (prioritized backlog), `loops/<name>/LOOP_LOG.md`
+(append-only run log). `/code-loop [name] [n]` works that project's backlog
+one item per iteration: test-first, verify, commit, log. A Stop hook
+(`hooks/verify-gate.sh`) blocks the agent from stopping until every armed
+project's verify command passes, with a 3-strike escalation that forces an
+honest FAILURE report instead of looping forever. For long unattended runs,
+`bin/code-loop <name> [n]` re-invokes `claude -p` with a fresh context per
+iteration.
 
-**Developer feedback loop** — `/feedback` shows what the loop did since your
-last review, collects your reactions, and converts every item into a durable
-artifact: a SPEC.md edit, a TODO.md item, or a CLAUDE.md rule. Feedback never
-lives only in chat.
+**Developer feedback loop** — `/feedback [name]` shows what the loop did since
+your last review, collects your reactions, and converts every item into a
+durable artifact: a SPEC.md edit, a TODO.md item, or a CLAUDE.md rule.
+Feedback never lives only in chat.
+
+**Maintenance** — `/loop-projects` lists every project with its backlog
+status, verify command, gate state, and last run; `/loop-projects clean
+<name>` removes a project (spec dir and runtime gate state).
+
+## Project resolution
+`/code-loop` and `/feedback` take the project name as their first argument.
+With no name they use the single existing project, and refuse to guess when
+several exist. `/loop-init` always requires a name (a kebab-case slug).
 
 ## Guardrails
-- No verify command in SPEC.md → /code-loop refuses to run.
+- No verify command in a project's SPEC.md → /code-loop refuses to run.
 - One TODO item per iteration; hard iteration budgets everywhere. The gate's
   3-strike escalation is per session, so under `bin/code-loop` (fresh context
   each iteration) a persistently-failing item gets a fresh 3-strike budget per
   iteration, up to the runner's `[n]` cap — it does not give up after 3 total.
 - Anti-reward-hacking rules in SPEC.md; the gate reports "do NOT weaken tests".
 - Known limitation: the agent could edit SPEC.md/.loop to weaken the gate, or
-  disarm it outright (`rm -f .loop/active`). The gate prevents accidental
+  disarm it outright (`rm -rf .loop/<name>`). The gate prevents accidental
   premature stops, not an adversarial agent — /feedback reviews diffs, so keep
   reviewing.
 - For UI work, point `Verify:` at a script that drives a browser (e.g. a
   Playwright check); the gate runs whatever command you give it.
 
 ## State files (in the target project)
-| File | Role |
+| Path | Role |
 |---|---|
-| SPEC.md | What to build + definition of done + verify/run commands |
-| TODO.md | Prioritized backlog; one checkbox per loop iteration |
-| LOOP_LOG.md | Append-only run + review log |
-| .loop/ | Gitignored runtime gate state (active, verify, blocks) |
+| `loops/<name>/SPEC.md` | What to build + definition of done + verify/run commands |
+| `loops/<name>/TODO.md` | Prioritized backlog; one checkbox per loop iteration |
+| `loops/<name>/LOOP_LOG.md` | Append-only run + review log |
+| `.loop/<name>/` | Gitignored runtime gate state (active, verify, blocks) |

--- a/plugins/loop-engineering/commands/code-loop.md
+++ b/plugins/loop-engineering/commands/code-loop.md
@@ -1,40 +1,70 @@
 ---
-description: Run the agentic coding loop — one TODO item per iteration, verified and committed, gated by the Stop-hook verify gate
+description: Run the agentic coding loop for one project — one TODO item per iteration, verified and committed, gated by the Stop-hook verify gate
+argument-hint: "[project] [max-iterations]"
 ---
 
 ## Context
 
-- Spec: !`cat SPEC.md 2>/dev/null || echo "MISSING — run /loop-init first"`
-- Backlog: !`cat TODO.md 2>/dev/null || echo "MISSING — run /loop-init first"`
-- Recent log: !`tail -20 LOOP_LOG.md 2>/dev/null`
+- Loop projects: !`ls loops 2>/dev/null || echo "NONE — run /loop-init <name> first"`
 - Branch: !`git branch --show-current`
 
 ## Your task
 
-Run the agentic coding loop. Max iterations this session: $ARGUMENTS (default 5 if empty or not a number).
+Run the agentic coding loop for ONE project. Arguments: $ARGUMENTS
+
+**Resolve the project and budget — before anything else:**
+1. Parse the arguments as `[project] [max-iterations]`:
+   - If the first token names a directory under `loops/`, that is the project;
+     an optional second numeric token is the iteration budget.
+   - If the only token is a number, it is the budget — usable only when exactly
+     one project exists.
+   - With no project token: if exactly one project exists, use it; if zero or
+     several exist, STOP and tell the user to run `/loop-init <name>` or pick
+     one (list them). Never guess among multiple projects.
+   - Budget defaults to 5.
+2. Set PROJ = `loops/<project>`. Read `PROJ/SPEC.md`, `PROJ/TODO.md`, and the
+   last ~20 lines of `PROJ/LOOP_LOG.md` before proceeding.
 
 **Preflight — do these before any code change:**
-1. If SPEC.md or TODO.md is MISSING, or SPEC.md's `## Verification` section has no `Verify:` line with a backticked command, STOP and tell the user to run `/loop-init`. Refuse to loop without a verify command.
-2. If on main/master, create and switch to a feature branch named after the top TODO item.
-3. Arm the verification gate:
-   - `mkdir -p .loop && printf '*\n' > .loop/.gitignore`
+3. If `PROJ/SPEC.md` or `PROJ/TODO.md` is missing, or SPEC.md's
+   `## Verification` section has no `Verify:` line with a backticked command,
+   STOP and tell the user to run `/loop-init <project>`. Refuse to loop without
+   a verify command.
+4. If on main/master, create and switch to a feature branch named
+   `<project>-<top TODO item slug>`.
+5. Arm the verification gate (state is per-project under `.loop/<project>/`):
+   - `mkdir -p .loop/<project> && printf '*\n' > .loop/.gitignore`
    - Extract the verify command deterministically (do NOT paraphrase it):
-     ``sed -n 's/^Verify: `\(.*\)`.*/\1/p' SPEC.md | head -n1 > .loop/verify``
-     Then `cat .loop/verify` — it must be a non-empty command with no backticks. If empty, STOP and tell the user SPEC.md's `Verify:` line is malformed.
-   - `touch .loop/active` and `rm -f .loop/blocks`.
+     ``sed -n 's/^Verify: `\(.*\)`.*/\1/p' PROJ/SPEC.md | head -n1 > .loop/<project>/verify``
+     Then `cat .loop/<project>/verify` — it must be a non-empty command with no
+     backticks. If empty, STOP and tell the user SPEC.md's `Verify:` line is
+     malformed.
+   - `touch .loop/<project>/active` and `rm -f .loop/<project>/blocks`.
 
 **Iterate — repeat up to the max-iterations budget:**
-4. Take the TOPMOST unchecked item in TODO.md. Work on ONLY that item this iteration.
-5. Implement it test-first: write the failing test, see it fail, implement, see it pass. Follow every rule in SPEC.md's `## Rules` section — in particular: no placeholders, and never touch tests/verifier/`.loop/` to make checks pass.
-6. Run the Verify command. If it fails, fix and re-run — do not proceed on red.
-7. On green: mark the item `- [x]` in TODO.md, append one line to LOOP_LOG.md — `## <date -Iseconds output> — <item> — PASS` — and commit everything for this item (code, tests, TODO.md, LOOP_LOG.md) in one commit.
-8. If an iteration reveals new necessary work, add it as a new `- [ ]` item to TODO.md (prioritized, not appended blindly) instead of expanding the current task.
+6. Take the TOPMOST unchecked item in `PROJ/TODO.md`. Work on ONLY that item
+   this iteration.
+7. Implement it test-first: write the failing test, see it fail, implement, see
+   it pass. Follow every rule in SPEC.md's `## Rules` section — in particular:
+   no placeholders, and never touch tests/verifier/`.loop/` to make checks pass.
+8. Run the Verify command. If it fails, fix and re-run — do not proceed on red.
+9. On green: mark the item `- [x]` in `PROJ/TODO.md`, append one line to
+   `PROJ/LOOP_LOG.md` — `## <date -Iseconds output> — <item> — PASS` — and
+   commit everything for this item (code, tests, TODO.md, LOOP_LOG.md) in one
+   commit.
+10. If an iteration reveals new necessary work, add it as a new `- [ ]` item to
+    `PROJ/TODO.md` (prioritized, not appended blindly) instead of expanding the
+    current task.
 
-**Finish — when TODO.md has no unchecked items OR the iteration budget is spent:**
-9. Run the Verify command one final time and report its real output.
-10. Disarm the gate: `rm -f .loop/active .loop/blocks`.
-11. Append a session summary to LOOP_LOG.md: items completed, items remaining, verify status, anything a human should review. Then give the user a 3-line summary and suggest `/feedback` for review.
+**Finish — when the TODO has no unchecked items OR the iteration budget is spent:**
+11. Run the Verify command one final time and report its real output.
+12. Disarm the gate: `rm -f .loop/<project>/active .loop/<project>/blocks`.
+13. Append a session summary to `PROJ/LOOP_LOG.md`: items completed, items
+    remaining, verify status, anything a human should review. Then give the
+    user a 3-line summary and suggest `/feedback <project>` for review.
 
-If verification cannot be made to pass after honest attempts, the Stop-hook gate will force a FAILURE report — write it honestly rather than weakening checks.
+If verification cannot be made to pass after honest attempts, the Stop-hook
+gate will force a FAILURE report — write it honestly rather than weakening
+checks.
 
 Do only these steps — no other actions.

--- a/plugins/loop-engineering/commands/feedback.md
+++ b/plugins/loop-engineering/commands/feedback.md
@@ -1,33 +1,48 @@
 ---
-description: Developer feedback loop — review the current product, turn every piece of feedback into a durable artifact (SPEC.md diff, TODO.md item, or CLAUDE.md rule), then optionally relaunch /code-loop
+description: Developer feedback loop for one project — review the current product, turn every piece of feedback into a durable artifact (SPEC.md diff, TODO.md item, or CLAUDE.md rule), then optionally relaunch /code-loop
+argument-hint: "[project]"
 ---
 
 ## Context
 
-- Spec: !`cat SPEC.md 2>/dev/null || echo "MISSING — run /loop-init first"`
-- Backlog: !`cat TODO.md 2>/dev/null`
-- Log since last review: !`awk '/^## REVIEW/{buf=""} {buf=buf $0 "\n"} END{printf "%s", buf}' LOOP_LOG.md 2>/dev/null | tail -40`
+- Loop projects: !`ls loops 2>/dev/null || echo "NONE — run /loop-init <name> first"`
 - Commits: !`git log --oneline -15`
 
 ## Your task
 
-Run one developer-feedback-loop review. This loop exists to inject the human's context advantage — their feedback outranks the spec.
+Run one developer-feedback-loop review for ONE project. This loop exists to
+inject the human's context advantage — their feedback outranks the spec.
+Arguments (optional project name): $ARGUMENTS
 
-1. If SPEC.md is MISSING, stop and point the user at `/loop-init`.
-2. **Present the current state** (keep it tight): what the loop completed since the last REVIEW entry, what verification currently says (run the Verify command from SPEC.md and report the real result), and how to see the product (the `Run:` command — offer to launch it).
-3. **Collect feedback.** Ask the user for their reactions: what's wrong, what's missing, what changed their mind. Free-form; iterate until they say they're done.
-4. **Convert EVERY feedback item into exactly one durable artifact** — never leave feedback as conversation only:
-   - Changed/clarified requirement or done-criterion → edit `SPEC.md` (Requirements or Definition of Done).
-   - New or reprioritized work → insert a `- [ ]` item into `TODO.md` at the right priority position.
-   - A correction the agent should apply to every future run (style, process, recurring mistake) → append a rule to `CLAUDE.md`.
+1. Resolve the project: use the argument if it names a directory under
+   `loops/`; with no argument, use the single existing project. If zero or
+   several projects exist and none was named, STOP and list them (or point at
+   `/loop-init <name>`). Set PROJ = `loops/<project>` and read `PROJ/SPEC.md`,
+   `PROJ/TODO.md`, and the portion of `PROJ/LOOP_LOG.md` since the last
+   `## REVIEW` entry.
+2. **Present the current state** (keep it tight): what the loop completed since
+   the last REVIEW entry, what verification currently says (run the Verify
+   command from `PROJ/SPEC.md` and report the real result), and how to see the
+   product (the `Run:` command — offer to launch it).
+3. **Collect feedback.** Ask the user for their reactions: what's wrong, what's
+   missing, what changed their mind. Free-form; iterate until they say they're
+   done.
+4. **Convert EVERY feedback item into exactly one durable artifact** — never
+   leave feedback as conversation only:
+   - Changed/clarified requirement or done-criterion → edit `PROJ/SPEC.md`
+     (Requirements or Definition of Done).
+   - New or reprioritized work → insert a `- [ ]` item into `PROJ/TODO.md` at
+     the right priority position.
+   - A correction the agent should apply to every future run (style, process,
+     recurring mistake) → append a rule to `CLAUDE.md`.
    Show the user each edit as you make it.
-5. **Record the review:** append to LOOP_LOG.md:
+5. **Record the review:** append to `PROJ/LOOP_LOG.md`:
 
 ```markdown
 ## REVIEW <date -Iseconds output>
 - Feedback: <item> → <artifact changed>
 ```
 
-6. Offer next steps: run `/code-loop` now, or stop here.
+6. Offer next steps: run `/code-loop <project>` now, or stop here.
 
 Do only these steps — no other actions.

--- a/plugins/loop-engineering/commands/loop-init.md
+++ b/plugins/loop-engineering/commands/loop-init.md
@@ -1,21 +1,29 @@
 ---
 allowed-tools: Read, Write, Bash(ls:*), Bash(cat:*)
-description: Scaffold loop-engineering state files (SPEC.md, TODO.md, LOOP_LOG.md) in the current project
+description: Scaffold a loop-engineering project (loops/<name>/ with SPEC.md, TODO.md, LOOP_LOG.md)
+argument-hint: <project-name> [description]
 ---
 
 ## Context
 
-- Existing SPEC.md: !`cat SPEC.md 2>/dev/null || echo "MISSING"`
-- Existing TODO.md: !`cat TODO.md 2>/dev/null || echo "MISSING"`
+- Existing loop projects: !`ls loops 2>/dev/null || echo "none"`
 - Project files: !`ls`
 
 ## Your task
 
-Scaffold the loop state files for this project. Arguments (optional project description): $ARGUMENTS
+Scaffold the state files for ONE named loop project. Arguments: $ARGUMENTS
+— the FIRST word is the project name (required); the rest is an optional
+project description.
 
-1. If SPEC.md already exists, STOP and tell the user it exists — never overwrite it.
-2. Interview the user briefly (one round of questions max) for anything you cannot infer from the project: the goal, the 3–7 core requirements, and the exact shell commands to build, test, and run this project.
-3. Write `SPEC.md` with EXACTLY these sections:
+1. If no project name was given, STOP and ask for one. The name must be a
+   short kebab-case slug (lowercase letters, digits, hyphens) — it becomes the
+   directory `loops/<name>/`. If the name is not a valid slug, STOP and say so.
+2. If `loops/<name>/SPEC.md` already exists, STOP and tell the user it exists —
+   never overwrite it. Mention `/loop-projects` to inspect existing projects.
+3. Interview the user briefly (one round of questions max) for anything you
+   cannot infer from the project: the goal, the 3–7 core requirements, and the
+   exact shell commands to build, test, and run this project.
+4. Write `loops/<name>/SPEC.md` with EXACTLY these sections:
 
 ```markdown
 # Spec: <project name>
@@ -43,7 +51,7 @@ Run: `<command to launch the app locally>`
 - If you learn a project-specific lesson, append it to CLAUDE.md.
 ```
 
-4. Write `TODO.md`:
+5. Write `loops/<name>/TODO.md`:
 
 ```markdown
 # TODO
@@ -52,9 +60,14 @@ Run: `<command to launch the app locally>`
 - [ ] <first task>
 ```
 
-   Derive initial items from the Requirements; each item must be completable in one loop iteration (roughly one focused change + its tests).
-5. Write `LOOP_LOG.md` containing only the line `# Loop Log` — it is append-only from here on.
-6. Confirm the Verify command actually runs (`Bash` it once); if it fails on a fresh scaffold, that is fine — report the output so the user knows the starting state.
-7. Tell the user: review/edit SPEC.md, then run `/code-loop` to start the loop.
+   Derive initial items from the Requirements; each item must be completable in
+   one loop iteration (roughly one focused change + its tests).
+6. Write `loops/<name>/LOOP_LOG.md` containing only the line `# Loop Log` — it
+   is append-only from here on.
+7. Confirm the Verify command actually runs (`Bash` it once); if it fails on a
+   fresh scaffold, that is fine — report the output so the user knows the
+   starting state.
+8. Tell the user: review/edit `loops/<name>/SPEC.md`, then run
+   `/code-loop <name>` to start the loop.
 
 Do only these steps — no other actions.

--- a/plugins/loop-engineering/commands/loop-projects.md
+++ b/plugins/loop-engineering/commands/loop-projects.md
@@ -1,0 +1,45 @@
+---
+allowed-tools: Read, Bash(ls:*), Bash(cat:*), Bash(grep:*), Bash(tail:*), Bash(rm:*), Bash(git:*)
+description: List loop-engineering projects with their status, or clean one up (loops/<name>/ plus its runtime gate state)
+argument-hint: "[clean <project>]"
+---
+
+## Context
+
+- Loop projects: !`ls loops 2>/dev/null || echo "NONE"`
+- Armed gates: !`ls .loop 2>/dev/null || echo "none"`
+
+## Your task
+
+Project maintenance for the loop-engineering plugin. Arguments: $ARGUMENTS
+
+**No arguments → LIST.** For each directory under `loops/`, report one line:
+
+- **name** — `<done>/<total>` TODO items done, verify command present/missing,
+  gate armed or not (`.loop/<name>/active` exists), and the timestamp of the
+  last `LOOP_LOG.md` entry (last `## ` line), or `never run`.
+
+Gather this with `grep -c '^- \[x\]' loops/<name>/TODO.md`,
+`grep -c '^- \[ \]'`, ``grep -c '^Verify: `' loops/<name>/SPEC.md``, and
+`tail` of the log. If `loops/` is missing or empty, say so and point at
+`/loop-init <name>`. End by mentioning `/loop-projects clean <name>`.
+
+**`clean <project>` → CLEAN.** Remove one project completely:
+
+1. If `loops/<project>` does not exist, STOP and list what does.
+2. Show the user what will be removed: the project's done/remaining TODO
+   counts, and whether `loops/<project>` has uncommitted changes
+   (`git status --porcelain -- loops/<project>`). If there are unchecked TODO
+   items or uncommitted changes, ask for confirmation before deleting;
+   otherwise proceed.
+3. Delete the runtime gate state first, then the project directory — always
+   from the parent, never `cd` into either:
+   - `rm -rf .loop/<project>`
+   - `git rm -r loops/<project>` if tracked (commit it as
+     `Remove loop project <project>`), else `rm -rf loops/<project>`.
+4. Confirm what was removed and list the remaining projects.
+
+Anything else in the arguments → show usage: `/loop-projects` to list,
+`/loop-projects clean <name>` to remove one.
+
+Do only these steps — no other actions.

--- a/plugins/loop-engineering/hooks/session-cleanup.sh
+++ b/plugins/loop-engineering/hooks/session-cleanup.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # SessionStart hook: a fresh session is never legitimately mid-gate, so clear
-# any stale gate state left by a crashed or abandoned /code-loop run.
+# stale per-project gate state (.loop/<project>/{active,blocks}) left by a
+# crashed or abandoned /code-loop run.
 # (Sessions spawned by bin/code-loop re-arm via /code-loop after this fires.)
 set -u
 input=$(cat)
 cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
 [ -n "$cwd" ] && [ -d "$cwd/.loop" ] || exit 0
-rm -f "$cwd/.loop/active" "$cwd/.loop/blocks"
+find "$cwd/.loop" -mindepth 2 -maxdepth 2 \( -name active -o -name blocks \) -type f -delete 2>/dev/null
 exit 0

--- a/plugins/loop-engineering/hooks/verify-gate.sh
+++ b/plugins/loop-engineering/hooks/verify-gate.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Stop-hook verification gate for the loop-engineering plugin.
-# Allows the agent to stop only when the project's verify command passes,
-# or after MAX_BLOCKS consecutive failures (then demands a FAILURE report).
+# Gate state is per-project: .loop/<project>/{active,verify,blocks}. The hook
+# checks EVERY armed project in the cwd: each passing project is disarmed, and
+# any failing project blocks the stop — so concurrent sessions looping on
+# different projects in the same repo cannot release each other's gates.
+# A project unblocks when its verify command passes, or after MAX_BLOCKS
+# consecutive failures (then the hook demands a FAILURE report).
 # stop_hook_active is deliberately NOT checked: the docs' "exit 0 if true"
 # pattern would defeat the gate; the blocks counter bounds re-blocking instead.
 set -u
@@ -12,33 +16,41 @@ cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
 [ -n "$cwd" ] && [ -d "$cwd" ] || exit 0
 cd "$cwd" || exit 0
 
-# Gate only applies while /code-loop has armed it in this project.
-[ -f .loop/active ] || exit 0
-# Strip backtick residue (sloppy extraction) and CR (CRLF-authored SPEC.md).
-verify_cmd=$(head -1 .loop/verify 2>/dev/null | tr -d '`\r')
-[ -n "$verify_cmd" ] || exit 0   # fail safe: never trap a session on broken state
+blocked=0
+for active in .loop/*/active; do
+  [ -f "$active" ] || continue   # unmatched glob or vanished file
+  dir=${active%/active}
+  project=${dir#.loop/}
+  # Strip backtick residue (sloppy extraction) and CR (CRLF-authored SPEC.md).
+  verify_cmd=$(head -1 "$dir/verify" 2>/dev/null | tr -d '`\r')
+  [ -n "$verify_cmd" ] || continue   # fail safe: never trap a session on broken state
 
-# Verify FIRST: a passing project always unblocks, even if a stale counter
-# is left over from a crashed run.
-if output=$(bash -c "$verify_cmd" 2>&1); then
-  rm -f .loop/active .loop/blocks
-  exit 0
-fi
+  # Verify FIRST: a passing project always unblocks, even if a stale counter
+  # is left over from a crashed run.
+  if output=$(bash -c "$verify_cmd" 2>&1); then
+    rm -f "$dir/active" "$dir/blocks"
+    continue
+  fi
 
-blocks=$(cat .loop/blocks 2>/dev/null || echo 0)
-case "$blocks" in (*[!0-9]*|'') blocks=0;; esac
-blocks=$((blocks + 1))
+  blocks=$(cat "$dir/blocks" 2>/dev/null || echo 0)
+  case "$blocks" in (*[!0-9]*|'') blocks=0;; esac
+  blocks=$((blocks + 1))
 
-if [ "$blocks" -ge "$MAX_BLOCKS" ]; then
-  rm -f .loop/active .loop/blocks
-  echo "Verification has failed $MAX_BLOCKS consecutive times. The gate is now DISARMED. Append a FAILURE report to LOOP_LOG.md (what is broken, what you tried, what a human should look at), then stop." >&2
-  exit 2
-fi
+  if [ "$blocks" -ge "$MAX_BLOCKS" ]; then
+    rm -f "$dir/active" "$dir/blocks"
+    echo "Verification for project '$project' has failed $MAX_BLOCKS consecutive times. Its gate is now DISARMED. Append a FAILURE report to loops/$project/LOOP_LOG.md (what is broken, what you tried, what a human should look at), then stop." >&2
+    blocked=1
+    continue
+  fi
 
-echo "$blocks" > .loop/blocks
-{
-  echo "STOP BLOCKED: verify command failed ($blocks/$MAX_BLOCKS): $verify_cmd"
-  echo "Fix the failure (do NOT weaken tests or the verifier), update LOOP_LOG.md, then try again. Output (last 2000 chars):"
-  printf '%s' "$output" | tail -c 2000
-} >&2
-exit 2
+  echo "$blocks" > "$dir/blocks"
+  {
+    echo "STOP BLOCKED: verify command for project '$project' failed ($blocks/$MAX_BLOCKS): $verify_cmd"
+    echo "Fix the failure (do NOT weaken tests or the verifier), update loops/$project/LOOP_LOG.md, then try again. Output (last 2000 chars):"
+    printf '%s' "$output" | tail -c 2000
+  } >&2
+  blocked=1
+done
+
+[ "$blocked" -eq 0 ] || exit 2
+exit 0

--- a/plugins/loop-engineering/tests/code-loop-runner-test.sh
+++ b/plugins/loop-engineering/tests/code-loop-runner-test.sh
@@ -3,6 +3,8 @@
 # INLINE prompt (not the /code-loop slash command, which does not load under
 # `claude -p`), enforces the project's Verify command itself, aborts on
 # reward-hacking, and bails with FAILURE after repeated no-progress iterations.
+# Loop state is per-project under loops/<name>/; the runner takes the project
+# name as its first argument.
 #
 # Uses a git-committing stub `claude` on PATH, driven by CLAUDE_STUB_MODE, so
 # the runner's real gate/hack/progress logic is exercised deterministically.
@@ -17,9 +19,9 @@ cat > "$root/stubbin/claude" <<'STUB'
 #!/usr/bin/env bash
 # $1=-p $2=<prompt>. Record the prompt, then act per CLAUDE_STUB_MODE:
 #   implement (default) do real work + commit; hack weaken a test + commit;
-#   noop do nothing.
+#   noop do nothing. CLAUDE_STUB_TODO points at the project's TODO.md.
 [ "${1:-}" = "-p" ] && printf '%s' "${2:-}" > "$CLAUDE_PROMPT_LOG"
-check_off() { awk '!d && /^- \[ \]/ {sub(/^- \[ \]/,"- [x]"); d=1} {print}' TODO.md > t && mv t TODO.md; }
+check_off() { awk '!d && /^- \[ \]/ {sub(/^- \[ \]/,"- [x]"); d=1} {print}' "$CLAUDE_STUB_TODO" > t && mv t "$CLAUDE_STUB_TODO"; }
 case "${CLAUDE_STUB_MODE:-implement}" in
   implement) touch DONE; check_off; git add -A; git commit -qm "stub: implement" ;;
   hack)      echo "exit 0" > tests/x_test.sh; touch DONE; check_off; git add -A; git commit -qm "stub: hack" ;;
@@ -29,30 +31,41 @@ echo '{"result":"stub"}'
 STUB
 chmod +x "$root/stubbin/claude"
 
-# Fresh git project whose Verify command passes only once a DONE marker exists.
-mkproj() { # n_items -> prints project dir
-  local n="$1" p k; p=$(mktemp -d)
+# Fresh git repo with one loop project whose Verify command passes only once a
+# DONE marker exists. mkproj <project> <n_items> -> prints repo dir.
+mkproj() {
+  local proj="$1" n="$2" p k; p=$(mktemp -d)
   ( cd "$p" || exit 1
     git init -q; git config user.email t@t; git config user.name t
-    # shellcheck disable=SC2016  # backticks are literal SPEC.md markup, not expansion
-    printf '# Spec\n\n## Verification\nVerify: `bash verify.sh`\n\n## Rules\n- no cheating\n' > SPEC.md
+    addproj "$p" "$proj" "$n"
     printf '[ -f DONE ]\n' > verify.sh
     mkdir -p tests; printf 'echo real test\n' > tests/x_test.sh
-    : > TODO.md; for k in $(seq 1 "$n"); do printf -- '- [ ] item %s\n' "$k" >> TODO.md; done
     git add -A; git commit -qm baseline ) >/dev/null 2>&1
   printf '%s' "$p"
 }
 
-run() { # mode dir budget -> sets RC, OUT
+# Add a loop project dir to an existing repo (no commit).
+addproj() { # repo project n_items
+  local p="$1" proj="$2" n="$3" k
+  mkdir -p "$p/loops/$proj"
+  # shellcheck disable=SC2016  # backticks are literal SPEC.md markup, not expansion
+  printf '# Spec\n\n## Verification\nVerify: `bash verify.sh`\n\n## Rules\n- no cheating\n' > "$p/loops/$proj/SPEC.md"
+  : > "$p/loops/$proj/TODO.md"
+  for k in $(seq 1 "$n"); do printf -- '- [ ] item %s\n' "$k" >> "$p/loops/$proj/TODO.md"; done
+  printf '# Loop Log\n' > "$p/loops/$proj/LOOP_LOG.md"
+}
+
+run() { # mode dir project budget -> sets RC, OUT
   OUT=$( cd "$2" && CLAUDE_STUB_MODE="$1" CLAUDE_PROMPT_LOG="$promptlog" \
-         PATH="$root/stubbin:$PATH" bash "$RUNNER" "$3" 2>&1 ); RC=$?
+         CLAUDE_STUB_TODO="loops/$3/TODO.md" \
+         PATH="$root/stubbin:$PATH" bash "$RUNNER" "$3" "$4" 2>&1 ); RC=$?
 }
 ok() { printf 'ok   - %s\n' "$1"; }
 no() { fails=$((fails + 1)); printf 'FAIL - %s\n' "$1"; }
 
 # 1. Happy path: real work -> exit 0, TODO complete.
-d=$(mkproj 1); run implement "$d" 5
-if [ "$RC" -eq 0 ] && ! grep -q '^- \[ \]' "$d/TODO.md" && printf '%s' "$OUT" | grep -q "TODO complete"; then
+d=$(mkproj alpha 1); run implement "$d" alpha 5
+if [ "$RC" -eq 0 ] && ! grep -q '^- \[ \]' "$d/loops/alpha/TODO.md" && printf '%s' "$OUT" | grep -q "TODO complete"; then
   ok "happy path completes (exit 0, TODO checked off)"
 else
   no "happy path (rc=$RC, out: $OUT)"
@@ -68,29 +81,62 @@ if grep -q 'bash verify.sh' "$promptlog"; then
 else
   no "inline prompt missing the Verify command"
 fi
+if grep -q 'loops/alpha/TODO.md' "$promptlog"; then
+  ok "inline prompt references the project-scoped TODO path"
+else
+  no "inline prompt missing project-scoped TODO path"
+fi
 
-# 2. Reward-hacking: weaken a test -> abort exit 3.
-d=$(mkproj 1); run hack "$d" 5
+# 2. Missing project argument -> usage error exit 2.
+d=$(mkproj alpha 1)
+OUT=$( cd "$d" && PATH="$root/stubbin:$PATH" bash "$RUNNER" 2>&1 ); RC=$?
+if [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qi "usage"; then
+  ok "missing project argument exits 2 with usage"
+else
+  no "missing project argument (rc=$RC, out: $OUT)"
+fi
+
+# 3. Unknown project -> exit 2, lists available projects.
+d=$(mkproj alpha 1)
+OUT=$( cd "$d" && PATH="$root/stubbin:$PATH" bash "$RUNNER" nosuch 2>&1 ); RC=$?
+if [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -q "alpha"; then
+  ok "unknown project exits 2 and lists available projects"
+else
+  no "unknown project (rc=$RC, out: $OUT)"
+fi
+
+# 4. Reward-hacking: weaken a test -> abort exit 3.
+d=$(mkproj alpha 1); run hack "$d" alpha 5
 if [ "$RC" -eq 3 ] && printf '%s' "$OUT" | grep -q "reward-hacking detected"; then
   ok "aborts (exit 3) when the loop modifies a protected file"
 else
   no "hack guard (rc=$RC, out: $OUT)"
 fi
 
-# 3. No verified progress: noop -> FAILURE exit 1 after MAX_STRIKES.
-d=$(mkproj 1); run noop "$d" 9
+# 5. No verified progress: noop -> FAILURE exit 1 after MAX_STRIKES.
+d=$(mkproj alpha 1); run noop "$d" alpha 9
 if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "FAILURE"; then
   ok "bails with FAILURE after repeated no-progress iterations"
 else
   no "no-progress bail (rc=$RC, out: $OUT)"
 fi
 
-# 4. Budget exhaustion: fewer iterations than items -> exit 1 with message.
-d=$(mkproj 2); run implement "$d" 1
+# 6. Budget exhaustion: fewer iterations than items -> exit 1 with message.
+d=$(mkproj alpha 2); run implement "$d" alpha 1
 if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "Budget exhausted"; then
   ok "budget exhaustion exits 1 with message"
 else
   no "budget exhaustion (rc=$RC, out: $OUT)"
+fi
+
+# 7. Isolation: running project alpha leaves project beta's files untouched.
+d=$(mkproj alpha 1); addproj "$d" beta 2
+( cd "$d" && git add -A && git commit -qm "add beta" ) >/dev/null 2>&1
+run implement "$d" alpha 5
+if [ "$RC" -eq 0 ] && [ "$(grep -c '^- \[ \]' "$d/loops/beta/TODO.md")" -eq 2 ]; then
+  ok "other project's TODO untouched"
+else
+  no "isolation (rc=$RC, beta TODO: $(cat "$d/loops/beta/TODO.md" 2>/dev/null))"
 fi
 
 if [ "$fails" -eq 0 ]; then echo "ALL PASS"; else echo "$fails FAILURES"; exit 1; fi

--- a/plugins/loop-engineering/tests/verify-gate-test.sh
+++ b/plugins/loop-engineering/tests/verify-gate-test.sh
@@ -3,6 +3,7 @@
 # SC2319: Intentional pattern — test harness deliberately captures $? from [ ... ] test to feed check().
 # SC2015: Intentional pattern — final line uses [ ... ] && echo ... || { ...; exit 1; } for control flow.
 # Tests for verify-gate.sh and session-cleanup.sh. Each case runs in its own temp dir.
+# Gate state is per-project: .loop/<project>/{active,verify,blocks}.
 set -u
 HOOKS_DIR="$(cd "$(dirname "$0")/../hooks" && pwd)"
 GATE="$HOOKS_DIR/verify-gate.sh"
@@ -20,6 +21,10 @@ new_case() { # $1=setup commands, run inside a fresh temp dir; echoes the dir
   echo "$tmp"
 }
 
+arm() { # $1=project $2=verify command — helper used inside new_case setups
+  mkdir -p ".loop/$1" && touch ".loop/$1/active" && printf '%s\n' "$2" > ".loop/$1/verify"
+}
+
 check() { # $1=name $2=expected $3=actual
   if [ "$2" = "$3" ]; then
     echo "PASS: $1"
@@ -29,42 +34,56 @@ check() { # $1=name $2=expected $3=actual
   fi
 }
 
-# 1. Gate not armed → allow stop immediately.
+# 1. No project armed → allow stop immediately.
 t=$(new_case "true")
 run_gate "$t"; check "disarmed gate allows stop" 0 $?
 
-# 2. Armed, verify passes → allow stop and disarm.
-t=$(new_case "mkdir .loop && touch .loop/active && echo 'true' > .loop/verify")
+# 2. Armed project, verify passes → allow stop and disarm that project.
+t=$(new_case "$(declare -f arm); arm alpha 'true'")
 run_gate "$t"; check "passing verify allows stop" 0 $?
-[ ! -f "$t/.loop/active" ]; check "passing verify disarms gate" 0 $?
+[ ! -f "$t/.loop/alpha/active" ]; check "passing verify disarms project" 0 $?
 
 # 3. Verify-before-escalate: passing verify with a stale maxed counter still allows stop.
-t=$(new_case "mkdir .loop && touch .loop/active && echo 'true' > .loop/verify && echo 3 > .loop/blocks")
+t=$(new_case "$(declare -f arm); arm alpha 'true' && echo 3 > .loop/alpha/blocks")
 run_gate "$t"; check "stale counter with passing verify allows stop" 0 $?
 
-# 4. Armed, verify fails → block (exit 2), counter incremented to 1.
-t=$(new_case "mkdir .loop && touch .loop/active && echo 'false' > .loop/verify")
+# 4. Armed, verify fails → block (exit 2), counter incremented to 1, message names the project.
+t=$(new_case "$(declare -f arm); arm alpha 'false'")
 run_gate "$t"; check "failing verify blocks stop" 2 $?
-check "blocks counter incremented" "1" "$(cat "$t/.loop/blocks")"
+check "blocks counter incremented" "1" "$(cat "$t/.loop/alpha/blocks")"
+grep -q "alpha" "$t/stderr.txt"; check "block message names the project" 0 $?
 
 # 5. Third consecutive failure → final block that disarms and demands a FAILURE report.
-t=$(new_case "mkdir .loop && touch .loop/active && echo 'false' > .loop/verify && echo 2 > .loop/blocks")
+t=$(new_case "$(declare -f arm); arm alpha 'false' && echo 2 > .loop/alpha/blocks")
 run_gate "$t"; check "third failure still blocks" 2 $?
-[ ! -f "$t/.loop/active" ]; check "third failure disarms gate" 0 $?
+[ ! -f "$t/.loop/alpha/active" ]; check "third failure disarms project" 0 $?
 grep -q "FAILURE report" "$t/stderr.txt"; check "third failure demands FAILURE report" 0 $?
 
 # 6. Malformed/missing verify file while armed → fail safe: allow stop (never trap the user).
-t=$(new_case "mkdir .loop && touch .loop/active")
+t=$(new_case "mkdir -p .loop/alpha && touch .loop/alpha/active")
 run_gate "$t"; check "missing verify file allows stop" 0 $?
 
 # 7. Backtick residue from sloppy extraction is stripped, not treated as command substitution.
-t=$(new_case "mkdir .loop && touch .loop/active && printf '%s\n' '\`true\`' > .loop/verify")
+t=$(new_case "$(declare -f arm); arm alpha '\`true\`'")
 run_gate "$t"; check "backtick-wrapped verify still runs" 0 $?
 
-# 8. SessionStart cleanup clears stale gate state.
-t=$(new_case "mkdir .loop && touch .loop/active && echo 2 > .loop/blocks")
+# 8. Two projects armed: passing one disarms, failing one blocks independently.
+t=$(new_case "$(declare -f arm); arm alpha 'true' && arm beta 'false'")
+run_gate "$t"; check "one failing project blocks stop" 2 $?
+[ ! -f "$t/.loop/alpha/active" ]; check "passing project disarmed" 0 $?
+[ -f "$t/.loop/beta/active" ]; check "failing project stays armed" 0 $?
+check "failing project counter incremented" "1" "$(cat "$t/.loop/beta/blocks")"
+
+# 9. Two projects armed, both pass → allow stop, both disarmed.
+t=$(new_case "$(declare -f arm); arm alpha 'true' && arm beta 'true'")
+run_gate "$t"; check "all projects passing allows stop" 0 $?
+[ ! -f "$t/.loop/alpha/active" ] && [ ! -f "$t/.loop/beta/active" ]; check "all passing projects disarmed" 0 $?
+
+# 10. SessionStart cleanup clears stale gate state for every project.
+t=$(new_case "$(declare -f arm); arm alpha 'true' && echo 2 > .loop/alpha/blocks && arm beta 'false'")
 printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$t" | "$CLEANUP" >/dev/null 2>&1
 check "session cleanup exits 0" 0 $?
-[ ! -f "$t/.loop/active" ] && [ ! -f "$t/.loop/blocks" ]; check "session cleanup removes gate state" 0 $?
+[ ! -f "$t/.loop/alpha/active" ] && [ ! -f "$t/.loop/alpha/blocks" ] && [ ! -f "$t/.loop/beta/active" ]
+check "session cleanup removes all projects' gate state" 0 $?
 
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILURES"; exit 1; }


### PR DESCRIPTION
## Summary

Adds multi-project support to the loop-engineering plugin. Each loop project is fully isolated in `loops/<name>/` with its own `SPEC.md`, `TODO.md`, and `LOOP_LOG.md`; runtime gate state is per-project under `.loop/<name>/`. The old root-level single-project layout is removed with **no backward compatibility**.

## Design

- **Layout** — tracked state in `loops/<name>/{SPEC,TODO,LOOP_LOG}.md`; gitignored runtime gate state in `.loop/<name>/{active,verify,blocks}`.
- **Project resolution** — `/loop-init <name>` requires an explicit kebab-case slug (creation never guesses). `/code-loop [name] [n]` and `/feedback [name]` auto-resolve only when exactly one project exists; with several they list and stop.
- **Maintenance** — new `/loop-projects` command: no args lists each project with done/total TODO counts, verify command presence, gate armed state, and last log entry; `clean <name>` removes a project (gate state first, then `git rm` if tracked, with confirmation when unchecked items or uncommitted changes exist).
- **Gate** — `verify-gate.sh` now iterates every armed `.loop/*/active`: passing projects disarm, any failing project blocks, with the same per-project 3-strike escalation. Concurrent sessions looping on different projects in one repo gate independently.
- **Headless runner** — `bin/code-loop <project> [n]`; usage/unknown-project errors exit 2 and list available projects. The reward-hacking guard tracks the project-scoped spec path.

## Testing

- `plugins/loop-engineering/tests/verify-gate-test.sh` — 20 checks, ALL PASS (new: multi-project block/disarm independence, cleanup across projects)
- `plugins/loop-engineering/tests/code-loop-runner-test.sh` — 10 checks, ALL PASS (new: missing/unknown project args, cross-project isolation)
- `shellcheck` clean on both hooks, both test files, and `bin/code-loop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pbWGye52pQCZdF6QX4hPC