### PR TITLE
Add tmux keybindings to join/break panes

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -109,3 +109,12 @@ set -g window-active-style 'bg=colour232'
 # preview boxes when a session has more windows than fit in one row.
 bind w choose-tree -Zw -N -N
 bind s choose-tree -Zs -N -N
+
+## Pull a pane from anywhere into a split in the current pane
+# Opens the full tree (sessions/windows/panes); pick a pane and it's
+# joined here as a split, instead of the default "switch to it".
+bind H choose-tree -Z "join-pane -h -s '%%'"
+bind V choose-tree -Z "join-pane -v -s '%%'"
+
+## Split the current pane out into its own new window
+bind N break-pane


### PR DESCRIPTION
## Summary
- `prefix + H` — pull a pane from the session tree into the current pane as a horizontal split
- `prefix + V` — pull a pane from the session tree into the current pane as a vertical split
- `prefix + N` — break the current pane out into its own new window

## Test plan
- [x] Verified new keybindings load without conflicts via an isolated `tmux -L conftest` server
- [ ] `prefix + r` to reload config in a live session and try `H`/`V`/`N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)