### PR TITLE
loop-engineering: enforce TODO item quality rules

### DIFF
--- a/plugins/loop-engineering/README.md
+++ b/plugins/loop-engineering/README.md
@@ -31,6 +31,15 @@ several exist. `/loop-init` always requires a name (a kebab-case slug).
 
 ## Guardrails
 - No verify command in a project's SPEC.md → /code-loop refuses to run.
+- TODO item quality, enforced whenever `/loop-init`, `/code-loop`, or
+  `/feedback` create or edit `TODO.md`: every implementation item must be
+  actionable from `SPEC.md` plus that single line alone; investigation
+  items are tagged `[INVESTIGATE]` and produce a written finding instead of
+  code; cross-item dependencies get an explicit `(ref: <exact text>)`
+  pointer instead of assumed shared context; and any item bundling more
+  than one focused change is split into smaller, independently-
+  implementable items. `/code-loop` re-splits an item on the spot if it
+  turns out not to be self-contained once work starts.
 - One TODO item per iteration; hard iteration budgets everywhere. The gate's
   3-strike escalation is per session, so under `bin/code-loop` (fresh context
   each iteration) a persistently-failing item gets a fresh 3-strike budget per

--- a/plugins/loop-engineering/commands/code-loop.md
+++ b/plugins/loop-engineering/commands/code-loop.md
@@ -44,17 +44,37 @@ Run the agentic coding loop for ONE project. Arguments: $ARGUMENTS
 **Iterate — repeat up to the max-iterations budget:**
 6. Take the TOPMOST unchecked item in `PROJ/TODO.md`. Work on ONLY that item
    this iteration.
-7. Implement it test-first: write the failing test, see it fail, implement, see
-   it pass. Follow every rule in SPEC.md's `## Rules` section — in particular:
-   no placeholders, and never touch tests/verifier/`.loop/` to make checks pass.
+7. Branch on item type:
+   - **`[INVESTIGATE]` item:** research the open question (read code, run
+     read-only commands, consult SPEC.md) and produce a written finding —
+     never product code. Record the finding as one or both of: a note
+     appended to `PROJ/LOOP_LOG.md`, or new implementation item(s) inserted
+     into `PROJ/TODO.md` that point back at this investigation via
+     `(ref: <exact text of this item>)`. Then proceed to step 8.
+   - **Implementation item (no tag):** before touching code, confirm the
+     line is fully actionable from `PROJ/SPEC.md` plus that single line
+     alone. If it silently depends on missing context (another item, an
+     unresolved investigation, an assumption not stated in SPEC.md), do NOT
+     guess — stop this iteration's implementation, rewrite the item in
+     `PROJ/TODO.md` (add an explicit `(ref: ...)` pointer, or split it into
+     smaller self-contained items per SPEC.md's TODO item-quality rules),
+     then restart step 6 against the revised topmost item. Otherwise
+     implement it test-first: write the failing test, see it fail,
+     implement, see it pass. Follow every rule in SPEC.md's `## Rules`
+     section — in particular: no placeholders, and never touch
+     tests/verifier/`.loop/` to make checks pass.
 8. Run the Verify command. If it fails, fix and re-run — do not proceed on red.
 9. On green: mark the item `- [x]` in `PROJ/TODO.md`, append one line to
    `PROJ/LOOP_LOG.md` — `## <date -Iseconds output> — <item> — PASS` — and
    commit everything for this item (code, tests, TODO.md, LOOP_LOG.md) in one
    commit.
-10. If an iteration reveals new necessary work, add it as a new `- [ ]` item to
-    `PROJ/TODO.md` (prioritized, not appended blindly) instead of expanding the
-    current task.
+10. If an iteration reveals new necessary work, add it as new item(s) to
+    `PROJ/TODO.md` (prioritized, not appended blindly) instead of expanding
+    the current task — following SPEC.md's TODO item-quality rules: tag
+    `[INVESTIGATE]` for open questions, keep every implementation item
+    self-contained (actionable from SPEC.md + that line alone), add
+    explicit `(ref: ...)` pointers for any cross-item dependency, and split
+    anything bundling more than one focused change into separate items.
 
 **Finish — when the TODO has no unchecked items OR the iteration budget is spent:**
 11. Run the Verify command one final time and report its real output.

--- a/plugins/loop-engineering/commands/feedback.md
+++ b/plugins/loop-engineering/commands/feedback.md
@@ -31,8 +31,16 @@ Arguments (optional project name): $ARGUMENTS
    leave feedback as conversation only:
    - Changed/clarified requirement or done-criterion → edit `PROJ/SPEC.md`
      (Requirements or Definition of Done).
-   - New or reprioritized work → insert a `- [ ]` item into `PROJ/TODO.md` at
-     the right priority position.
+   - New or reprioritized work → insert an item into `PROJ/TODO.md` at the
+     right priority position, following SPEC.md's TODO item-quality rules:
+     tag it `- [ ] [INVESTIGATE] <question>` if it's an open question rather
+     than ready-to-build work; otherwise make it a plain implementation item
+     that is fully actionable from SPEC.md plus that single line alone. If
+     the feedback only makes sense alongside another TODO item or a past
+     investigation's finding, add an explicit `(ref: <exact text of the
+     other item>)` pointer rather than leaving the connection implicit. If a
+     single piece of feedback bundles more than one focused change, split it
+     into multiple items now rather than filing one compound item.
    - A correction the agent should apply to every future run (style, process,
      recurring mistake) → append a rule to `CLAUDE.md`.
    Show the user each edit as you make it.

--- a/plugins/loop-engineering/commands/loop-init.md
+++ b/plugins/loop-engineering/commands/loop-init.md
@@ -23,7 +23,10 @@ project description.
 3. Interview the user briefly (one round of questions max) for anything you
    cannot infer from the project: the goal, the 3–7 core requirements, and the
    exact shell commands to build, test, and run this project.
-4. Write `loops/<name>/SPEC.md` with EXACTLY these sections:
+4. Write `loops/<name>/SPEC.md` with EXACTLY these sections. Note the
+   `## Rules` section includes the TODO item-quality rules that
+   `/code-loop` and `/feedback` also enforce whenever they add or edit
+   items later:
 
 ```markdown
 # Spec: <project name>
@@ -49,19 +52,51 @@ Run: `<command to launch the app locally>`
 - One TODO item per iteration: implement, verify, commit, update TODO.md.
 - When a decision changes the spec, edit this file in the same commit.
 - If you learn a project-specific lesson, append it to CLAUDE.md.
+- TODO item quality (applies whenever TODO.md is created or edited):
+  - Every implementation item must be fully actionable from this SPEC.md
+    plus that single TODO line alone — no missing context.
+  - Investigation items are tagged `[INVESTIGATE]` and are kept distinct
+    from implementation items — they produce a written finding, never
+    product code.
+  - A cross-item dependency gets an explicit `(ref: <exact text of the
+    other item>)` pointer — never an assumption of shared context.
+  - Any item covering more than one focused change is split into
+    separate, independently-implementable items.
 ```
 
 5. Write `loops/<name>/TODO.md`:
 
 ```markdown
 # TODO
-<!-- One `- [ ]` item per line, highest priority first. /code-loop works top-down, one item per iteration. -->
+<!-- One `- [ ]` item per line, highest priority first. /code-loop works
+top-down, one item per iteration.
+
+Two item types:
+  - Implementation item (default, no tag): must be fully actionable from
+    SPEC.md plus that single line alone — no missing context. Ready to
+    build test-first, this iteration, in isolation.
+  - `- [ ] [INVESTIGATE] <question>`: an open question that must be
+    resolved before dependent work can be scoped. Produces a written
+    finding (a note in LOOP_LOG.md, and/or new referenced implementation
+    items), never product code.
+
+If an item depends on another item or a prior investigation's finding,
+add an explicit `(ref: <exact text of the other item>)` pointer instead
+of assuming shared context. Split any item that bundles more than one
+focused change into separate, independently-implementable items. -->
 
 - [ ] <first task>
 ```
 
-   Derive initial items from the Requirements; each item must be completable in
-   one loop iteration (roughly one focused change + its tests).
+   Derive initial items from the Requirements. Classify each as an
+   implementation item (default) or `[INVESTIGATE]` (an open question that
+   must be answered before dependent work can be scoped). Each implementation
+   item must be self-contained — actionable from SPEC.md plus that single
+   line, with no unstated dependencies — and completable in one loop
+   iteration (roughly one focused change + its tests). If an item depends on
+   another item's outcome, add an explicit `(ref: ...)` pointer to it rather
+   than assuming shared context. Break any multi-part or ambiguous
+   requirement into several smaller items now, before the loop starts.
 6. Write `loops/<name>/LOOP_LOG.md` containing only the line `# Loop Log` — it
    is append-only from here on.
 7. Confirm the Verify command actually runs (`Bash` it once); if it fails on a


### PR DESCRIPTION
## Summary
- Require implementation TODO items to be self-contained — actionable from `SPEC.md` + the item line alone, with no unstated dependencies.
- Tag investigation-type items `[INVESTIGATE]` and keep them structurally distinct from implementation items; they produce a written finding instead of code.
- Require an explicit `(ref: <exact text>)` pointer whenever an item depends on another item or a prior investigation's finding, instead of assumed shared context.
- Require compound/complex items to be split into smaller, independently-implementable pieces.
- Applied consistently everywhere TODO.md is created or edited: `/loop-init` (initial scaffold + SPEC.md Rules template), `/code-loop` (mid-loop additions, plus a new branch for working `[INVESTIGATE]` items and an on-the-spot rewrite/split if an item turns out not to be self-contained), and `/feedback` (review-driven insertions).
- Updated the plugin README guardrails section to document the invariant.

## Test plan
- [x] Ran `plugins/loop-engineering/tests/code-loop-runner-test.sh` — all pass (mechanical checkbox-toggling runner is unaffected by these prompt-level rules).
- [ ] Manually exercise `/loop-init`, `/code-loop`, and `/feedback` on a sample project to confirm the new TODO item classification/reference/split behavior reads as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pbWGye52pQCZdF6QX4hPC